### PR TITLE
Added "Auto replace curiosities" option

### DIFF
--- a/src/haven/Config.java
+++ b/src/haven/Config.java
@@ -107,6 +107,7 @@ public class Config {
     public static boolean showplayerpaths = Utils.getprefb("showplayerpaths", false);
     public static boolean showanimalpaths = Utils.getprefb("showanimalpaths", false);
     public static boolean showstudylefttime = Utils.getprefb("showstudylefttime", false);
+    public static boolean autoreplacecurios = Utils.getprefb("autoreplacecurios", false);
     public static boolean autopick = Utils.getprefb("autopick", false);
     public static Coord chatsz = Utils.getprefc("chatsz", Coord.z);
     public static boolean alternmapctrls = Utils.getprefb("alternmapctrls", false);

--- a/src/haven/Inventory.java
+++ b/src/haven/Inventory.java
@@ -131,7 +131,7 @@ public class Inventory extends Widget implements DTarget {
         }
     }
 
-    private List<WItem> getitems(GItem item) {
+    public List<WItem> getitems(GItem item) {
         List<WItem> items = new ArrayList<WItem>();
         String name = item.spr().getname();
         String resname = item.resource().name;

--- a/src/haven/OptWnd.java
+++ b/src/haven/OptWnd.java
@@ -708,6 +708,18 @@ public class OptWnd extends Window {
                 a = val;
             }
         }, new Coord(260, y));
+        y += 35;
+        display.add(new CheckBox("Auto replace curiosities") {
+            {
+                a = Config.autoreplacecurios;
+            }
+
+            public void set(boolean val) {
+                Utils.setprefb("autoreplacecurios", val);
+                Config.autoreplacecurios = val;
+                a = val;
+            }
+        }, new Coord(260, y));
 
         display.add(new Button(220, "Reset Windows (req. logout)") {
             @Override

--- a/src/haven/WItem.java
+++ b/src/haven/WItem.java
@@ -294,6 +294,15 @@ public class WItem extends Widget implements DTarget {
                 Resource.Tooltip tt = item.resource().layer(Resource.Tooltip.class);
                 if (tt != null)
                     gameui().syslog.append(tt.t + " LP: " + ci.exp, Color.LIGHT_GRAY);
+
+                if (Config.autoreplacecurios) {
+                    // It doesn't work properly when several container-like widgets opened,
+                    // but I don't see any better way to accomplish this task
+                    List<WItem> similaritems = gameui().maininv.getitems(this.item);
+                    if (similaritems.size() > 0) {
+                        similaritems.get(0).item.wdgmsg("transfer", Coord.z);
+                    }
+                }
             }
         } catch (Loading l) {
         }


### PR DESCRIPTION
Added an ability to auto-replace studied curiosities

Unfortunately it doesn't work properly when several container-like widgets opened, but I don't see any better way to accomplish this task