### PR TITLE
Added "Show FPS" option

### DIFF
--- a/src/haven/Config.java
+++ b/src/haven/Config.java
@@ -102,6 +102,7 @@ public class Config {
     public static boolean showweather = Utils.getprefb("showweather", true);
     public static boolean simplecrops = Utils.getprefb("simplecrops", false);
     public static boolean simpleforage = Utils.getprefb("simpleforage", false);
+    public static boolean showfps = Utils.getprefb("showfps", false);
     public static boolean autohearth = Utils.getprefb("autohearth", false);
     public static boolean servertime = Utils.getprefb("servertime", false);
     public static boolean showplayerpaths = Utils.getprefb("showplayerpaths", false);

--- a/src/haven/HavenPanel.java
+++ b/src/haven/HavenPanel.java
@@ -302,6 +302,10 @@ public class HavenPanel extends GLCanvas implements Runnable, Console.Directory 
             ui.draw(g);
         }
 
+        if (Config.showfps) {
+            FastText.aprintf(g, new Coord(HavenPanel.w - 50, 15), 0, 1, "FPS: %d", fps);
+        }
+
         if (Config.dbtext) {
             int y = h - 150;
             FastText.aprintf(g, new Coord(10, y -= 15), 0, 1, "FPS: %d (%d%%, %d%% idle)", fps, (int) (uidle * 100.0), (int) (ridle * 100.0));

--- a/src/haven/OptWnd.java
+++ b/src/haven/OptWnd.java
@@ -239,6 +239,18 @@ public class OptWnd extends Window {
                         a = val;
                     }
                 }, new Coord(0, y));
+                y += 35;
+                add(new CheckBox("Show FPS") {
+                    {
+                        a = Config.showfps;
+                    }
+
+                    public void set(boolean val) {
+                        Utils.setprefb("showfps", val);
+                        Config.showfps = val;
+                        a = val;
+                    }
+                }, new Coord(0, y));
                 pack();
             }
         }


### PR DESCRIPTION
Yeah, I know that there is the "-d" command line option atm (and it can be enabled via "haven.dbtext" as well) but it shows a lot of unnecessary info for the ordinary users and renders it over the chat window, so I think that giving users the "Show FPS" option is much better than what they have right now