### PR TITLE
Reworked "Select syslog on login" feature

### DIFF
--- a/src/haven/ChatUI.java
+++ b/src/haven/ChatUI.java
@@ -161,7 +161,7 @@ public class ChatUI extends Widget {
     public static abstract class Channel extends Widget {
         public final List<Message> msgs = new LinkedList<Message>();
         private final Scrollbar sb;
-        private final IButton cb;
+        public final IButton cb;
         public int urgency = 0;
 
         public static abstract class Message {

--- a/src/haven/Config.java
+++ b/src/haven/Config.java
@@ -107,6 +107,7 @@ public class Config {
     public static boolean showplayerpaths = Utils.getprefb("showplayerpaths", false);
     public static boolean showanimalpaths = Utils.getprefb("showanimalpaths", false);
     public static boolean showstudylefttime = Utils.getprefb("showstudylefttime", false);
+    public static boolean selectsyslogonlogin = Utils.getprefb("selectsyslogonlogin", false);
     public static boolean autopick = Utils.getprefb("autopick", false);
     public static Coord chatsz = Utils.getprefc("chatsz", Coord.z);
     public static boolean alternmapctrls = Utils.getprefb("alternmapctrls", false);

--- a/src/haven/GameUI.java
+++ b/src/haven/GameUI.java
@@ -71,6 +71,7 @@ public class GameUI extends ConsoleHost implements Console.Directory {
     public TimersWnd timerswnd;
     public QuickSlotsWdg quickslots;
     public StatusWdg statuswindow;
+    private boolean firstdraw = true;
 
     public abstract class Belt extends Widget {
         public Belt(Coord sz) {
@@ -586,6 +587,11 @@ public class GameUI extends ConsoleHost implements Console.Directory {
     }
 
     public void draw(GOut g) {
+        if (Config.selectsyslogonlogin && firstdraw) {
+            chat.select(syslog);
+        }
+        firstdraw = false;
+
         beltwdg.c = new Coord(chat.c.x, Math.min(chat.c.y - beltwdg.sz.y + 4, sz.y - beltwdg.sz.y));
         super.draw(g);
         if (prog >= 0)

--- a/src/haven/GameUI.java
+++ b/src/haven/GameUI.java
@@ -71,7 +71,6 @@ public class GameUI extends ConsoleHost implements Console.Directory {
     public TimersWnd timerswnd;
     public QuickSlotsWdg quickslots;
     public StatusWdg statuswindow;
-    private boolean firstdraw = true;
 
     public abstract class Belt extends Widget {
         public Belt(Coord sz) {
@@ -521,7 +520,11 @@ public class GameUI extends ConsoleHost implements Console.Directory {
             zerg.ntab(polity = (Polity) child, zerg.pol);
             zerg.pol.tooltip = Text.render(polity.cap);
         } else if (place == "chat") {
+            ChatUI.Channel prevchannel = chat.sel;
             chat.addchild(child);
+            if (Config.selectsyslogonlogin && prevchannel != null && chat.sel.cb == null) {
+                 chat.select(prevchannel);
+            }
         } else if (place == "party") {
             add(child, 10, 95);
         } else if (place == "meter") {
@@ -587,11 +590,6 @@ public class GameUI extends ConsoleHost implements Console.Directory {
     }
 
     public void draw(GOut g) {
-        if (Config.selectsyslogonlogin && firstdraw) {
-            chat.select(syslog);
-        }
-        firstdraw = false;
-
         beltwdg.c = new Coord(chat.c.x, Math.min(chat.c.y - beltwdg.sz.y + 4, sz.y - beltwdg.sz.y));
         super.draw(g);
         if (prog >= 0)

--- a/src/haven/OptWnd.java
+++ b/src/haven/OptWnd.java
@@ -701,6 +701,18 @@ public class OptWnd extends Window {
                 a = val;
             }
         }, new Coord(260, y));
+        y += 35;
+        display.add(new CheckBox("Select syslog on login") {
+            {
+                a = Config.selectsyslogonlogin;
+            }
+
+            public void set(boolean val) {
+                Utils.setprefb("selectsyslogonlogin", val);
+                Config.selectsyslogonlogin = val;
+                a = val;
+            }
+        }, new Coord(260, y));
 
         display.add(new Button(220, "Reset Windows (req. logout)") {
             @Override


### PR DESCRIPTION
Now it selects the previous chat immediately after adding the new one if the new one can't be closed (yeah, it will result in non-automatically selected party and village chats, but I don't think that it's a problem at all)