### PR TITLE
Fixed minutes format on curios time left

### DIFF
--- a/src/haven/GItem.java
+++ b/src/haven/GItem.java
@@ -200,7 +200,7 @@ public class GItem extends AWidget implements ItemInfo.SpriteOwner, GSprite.Owne
         int hoursleft = timeleft / 60;
         int minutesleft = timeleft - hoursleft * 60;
 
-        timelefttex = Text.renderstroked(String.format("%d:%d", hoursleft, minutesleft), Color.WHITE, Color.BLACK, Text.numfnd).tex();
+        timelefttex = Text.renderstroked(String.format("%d:%02d", hoursleft, minutesleft), Color.WHITE, Color.BLACK, Text.numfnd).tex();
         return true;
     }
 


### PR DESCRIPTION
Will correctly display time remaining as, for example, "1:09" instead of "1:9" on curios being studied.