### PR TITLE
option to restrict dropping to ctrl+lmb, do moving instead if no ctrl

### DIFF
--- a/src/haven/Config.java
+++ b/src/haven/Config.java
@@ -126,6 +126,7 @@ public class Config {
     public static double alarmmammothvol = Utils.getprefd("alarmmammothvol", 0.8);
     public static boolean showcooldown = Utils.getprefb("showcooldown", false);
     public static boolean nodropping = Utils.getprefb("nodropping", false);
+    public static boolean nodropping_all = Utils.getprefb("nodropping_all", false);
     public static boolean fbelt = Utils.getprefb("fbelt", false);
     public static boolean histbelt = Utils.getprefb("histbelt", false);
     public static boolean dropore = Utils.getprefb("dropore", true);

--- a/src/haven/MapView.java
+++ b/src/haven/MapView.java
@@ -1979,11 +1979,29 @@ public class MapView extends PView implements DTarget, Console.Directory, PFList
     public boolean drop(final Coord cc, final Coord ul) {
         delay(new Hittest(cc) {
             public void hit(Coord pc, Coord2d mc, ClickInfo inf) {
-                if (Config.nodropping && !ui.modctrl) {
-                    int t = glob.map.gettile(player().rc.floor(tilesz));
-                    Resource res = glob.map.tilesetr(t);
-                    if (res != null && (res.name.equals("gfx/tiles/water") || res.name.equals("gfx/tiles/deep")))
+                if ((Config.nodropping || Config.nodropping_all) && !ui.modctrl) {
+                    // no dropping at all or when we are on water
+                    boolean nodropping = false;
+                    if (Config.nodropping_all) {
+                        // no dropping over anywhere
+                        nodropping = true;
+                    } else {
+                        // we came here because Config.nodropping is set, check water tiles
+                        int t = glob.map.gettile(player().rc.floor(tilesz));
+                        Resource res = glob.map.tilesetr(t);
+                        if (res != null && (res.name.equals("gfx/tiles/water") || res.name.equals("gfx/tiles/deep"))) {
+                            nodropping = true;
+                        }
+                    }
+                    if (nodropping) {
+                        // we really don't want dropping, so click is moving
+                        if (Config.pf) {
+                            pfLeftClick(mc.floor(), null);
+                        } else {
+                            wdgmsg("click", pc, mc.floor(posres), 1, 0);
+                        }
                         return;
+                	}
                 }
                 wdgmsg("drop", pc, mc.floor(posres), ui.modflags());
             }

--- a/src/haven/OptWnd.java
+++ b/src/haven/OptWnd.java
@@ -1030,6 +1030,17 @@ public class OptWnd extends Window {
                 a = val;
             }
         });
+        appender.add(new CheckBox("Disable dropping items over anywhere (overridable with Ctrl)") {
+            {
+                a = Config.nodropping_all;
+            }
+
+            public void set(boolean val) {
+                Utils.setprefb("nodropping_all", val);
+                Config.nodropping_all = val;
+                a = val;
+            }
+        });
         appender.add(new CheckBox("Enable full zoom-out in Ortho cam") {
             {
                 a = Config.enableorthofullzoom;


### PR DESCRIPTION
An enhance to the no-dropping-over-water option.

If this new option is on, when you are holding an item on cursor, click lmb = moving as if you are holding nothing, ctrl + lmb = dropping item.

Why I find this option useful:

Accidentally dropping a tiny item on ground while is not as bad as dropping to water, is somewhat annoying.
When transferring liquids or powders, it's convenient if I can move without puting down the item, especially if this movement needs to turn to another direction (so I have to click the ground).
Actually I don't usually take to-drop items in hand, I always ctrl+click it in the inventory directly, so this option adds no trouble to me.